### PR TITLE
Update version of javadoc plugin to 3.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 sudo: false
-install: true
 
 script: ./travis.sh
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <version.beanshell.plugin>1.4</version.beanshell.plugin>
     <version.jar.plugin>3.0.2</version.jar.plugin>
     <version.jarjar.plugin>1.9</version.jarjar.plugin>
-    <version.javadoc.plugin>3.0.0-M1</version.javadoc.plugin>
+    <version.javadoc.plugin>3.1.0</version.javadoc.plugin>
     <version.plugin.plugin>3.5</version.plugin.plugin>
     <version.resources.plugin>3.0.2</version.resources.plugin>
     <version.shade.plugin>3.1.0</version.shade.plugin>

--- a/travis.sh
+++ b/travis.sh
@@ -9,7 +9,6 @@ function installTravisTools {
 }
 
 installTravisTools
-. installJDK8
 
 # get current version from pom
 CURRENT_VERSION=`maven_expression "project.version"`


### PR DESCRIPTION
Needed to fix the issue generating javadoc on Java 11, v3.1.0 will use maven.compiler.release option to configure itself