### PR TITLE
pom: Replace Google Group by Discourse Community

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,8 @@
 
   <mailingLists>
     <mailingList>
-      <name>SonarQue mailing list</name>
-      <subscribe>sonarqube+subscribe@googlegroups.com</subscribe>
-      <unsubscribe>sonarqube+unsubscribe@googlegroups.com</unsubscribe>
-      <post>sonarqube@googlegroups.com</post>
+      <name>SonarSource Community</name>
+      <archive>https://community.sonarsource.com</archive>
     </mailingList>
   </mailingLists>
 


### PR DESCRIPTION
This change should be valid as per https://maven.apache.org/pom.html#Mailing_Lists 

The `subscribe`, `unsubscribe` and `post` are supposed to be email addresses, but `archive` should be a URL and so valid to use here.