### PR TITLE
Minor updates/cleanups

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,11 +60,6 @@
     </mailingList>
   </mailingLists>
 
-  <prerequisites>
-    <!-- Note that "prerequisites" not inherited, but used by versions-maven-plugin -->
-    <maven>${maven.min.version}</maven>
-  </prerequisites>
-
   <scm>
     <connection>scm:git:https://github.com/SonarSource/parent-oss.git</connection>
     <developerConnection>scm:git:git@github.com:SonarSource/parent-oss.git</developerConnection>
@@ -125,7 +120,6 @@
     <version.artifactory.plugin>2.6.1</version.artifactory.plugin>
     <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
 
-    <version.animal-sniffer.plugin>1.14</version.animal-sniffer.plugin>
     <version.buildnumber.plugin>1.4</version.buildnumber.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>
 
@@ -134,11 +128,6 @@
 
     <version.codehaus.license.plugin>1.16</version.codehaus.license.plugin>
     <version.mycila.license.plugin>3.0</version.mycila.license.plugin>
-
-    <!-- ===================== -->
-    <!-- Dependencies versions -->
-    <!-- ===================== -->
-    <version.sonar-jacoco-listeners>4.14.0.11784</version.sonar-jacoco-listeners>
 
     <!-- To configure maven-license-plugin to check license headers -->
     <license.name>GNU LGPL v3</license.name>
@@ -282,7 +271,7 @@
           <version>${version.javadoc.plugin}</version>
           <configuration>
             <quiet>true</quiet>
-            <additionalparam>-Xdoclint:none</additionalparam>
+            <doclint>none</doclint>
           </configuration>
         </plugin>
         <plugin>
@@ -364,7 +353,6 @@
         <configuration>
           <source>${jdk.min.version}</source>
           <target>${jdk.min.version}</target>
-          <encoding>${project.build.sourceEncoding}</encoding>
         </configuration>
       </plugin>
 
@@ -439,15 +427,6 @@
                   <banRelease>true</banRelease>
                   <phases>clean,deploy</phases>
                 </requirePluginVersions>
-
-                <bannedDependencies>
-                  <!-- See SONARPLUGINS-506 -->
-                  <message>Animal-sniffer throws exception when icu4j version 2.6.1 used.</message>
-                  <searchTransitive>true</searchTransitive>
-                  <excludes>
-                    <exclude>com.ibm.icu:icu4j:[2.6.1]</exclude>
-                  </excludes>
-                </bannedDependencies>
 
                 <!-- TODO SONARPLUGINS-797
                 <DependencyConvergence />
@@ -583,7 +562,6 @@
         </property>
       </activation>
       <properties>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
         <license.skip>true</license.skip>
         <enforcer.skip>true</enforcer.skip>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -99,26 +99,26 @@
     <!-- ================ -->
     <!-- Plugins versions -->
     <!-- ================ -->
-    <version.assembly.plugin>3.1.0</version.assembly.plugin>
-    <version.clean.plugin>3.0.0</version.clean.plugin>
-    <version.compiler.plugin>3.7.0</version.compiler.plugin>
-    <version.dependency.plugin>3.0.2</version.dependency.plugin>
-    <version.deploy.plugin>2.8.2</version.deploy.plugin>
+    <version.assembly.plugin>3.1.1</version.assembly.plugin>
+    <version.clean.plugin>3.1.0</version.clean.plugin>
+    <version.compiler.plugin>3.8.1</version.compiler.plugin>
+    <version.dependency.plugin>3.1.1</version.dependency.plugin>
+    <version.deploy.plugin>3.0.0-M1</version.deploy.plugin>
     <version.enforcer.plugin>3.0.0-M1</version.enforcer.plugin>
-    <version.surefire.plugin>2.22.0</version.surefire.plugin>
+    <version.surefire.plugin>2.22.2</version.surefire.plugin>
     <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
-    <version.install.plugin>2.5.2</version.install.plugin>
+    <version.install.plugin>3.0.0-M1</version.install.plugin>
     <version.beanshell.plugin>1.4</version.beanshell.plugin>
-    <version.jar.plugin>3.0.2</version.jar.plugin>
+    <version.jar.plugin>3.1.2</version.jar.plugin>
     <version.jarjar.plugin>1.9</version.jarjar.plugin>
     <version.javadoc.plugin>3.1.0</version.javadoc.plugin>
-    <version.plugin.plugin>3.5</version.plugin.plugin>
-    <version.resources.plugin>3.0.2</version.resources.plugin>
-    <version.shade.plugin>3.1.0</version.shade.plugin>
-    <version.source.plugin>3.0.1</version.source.plugin>
-    <version.site.plugin>3.7</version.site.plugin>
+    <version.plugin.plugin>3.6.0</version.plugin.plugin>
+    <version.resources.plugin>3.1.0</version.resources.plugin>
+    <version.shade.plugin>3.2.1</version.shade.plugin>
+    <version.source.plugin>3.1.0</version.source.plugin>
+    <version.site.plugin>3.7.1</version.site.plugin>
     <version.artifactory.plugin>2.6.1</version.artifactory.plugin>
-    <version.jacoco.plugin>0.8.3</version.jacoco.plugin>
+    <version.jacoco.plugin>0.8.4</version.jacoco.plugin>
 
     <version.buildnumber.plugin>1.4</version.buildnumber.plugin>
     <version.native2ascii.plugin>1.0-beta-1</version.native2ascii.plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.min.version>3.0.5</maven.min.version>
+    <maven.min.version>3.3.9</maven.min.version>
     <jdk.min.version>1.8</jdk.min.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>


### PR DESCRIPTION
Removing deprecated settings:
- prerequisites are basically useless since Maven 3
- Properties for animal-sniffer and sonar-jacoco-listeners are unused after recent changes
- ` <encoding>` for `maven-compiler-plugin` is already the default
- Other bits and pieces of animal-sniffer leftovers

Requiring Maven 3.3.9:
- jacoco 0.8.3 declares this, so we should follow suit
- Reasonably modern (released 2015-11-14)
- Available on all modern Travis-CI build nodes

Updating maven plug-ins:
- Checked via `mvn versions:display-plugin-updates`
- Most changes in those updates are to support Java 9/10/11 features & bug fixes
- Kept plug-ins which I don't have experience with at their current version