### PR TITLE
Bump version of licensing plugin to 2.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <version.sonar-packaging.plugin>1.18.0.372</version.sonar-packaging.plugin>
     <version.sonar-dev.plugin>1.8</version.sonar-dev.plugin>
 
-    <version.codehaus.license.plugin>1.16</version.codehaus.license.plugin>
+    <version.codehaus.license.plugin>2.0.0</version.codehaus.license.plugin>
     <version.mycila.license.plugin>3.0</version.mycila.license.plugin>
 
     <!-- To configure maven-license-plugin to check license headers -->


### PR DESCRIPTION
I encountered an issue using overrideUrl with 1.16 which is fixed in 2.0.0 . See https://github.com/mojohaus/license-maven-plugin/issues/331