### PR TITLE
Split JDK min version from enforcer min version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,6 +79,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.min.version>3.3.9</maven.min.version>
     <jdk.min.version>8</jdk.min.version>
+    <enforcer.jdk.min.version>1.${jdk.min.version}</enforcer.jdk.min.version>
     <timestamp>${maven.build.timestamp}</timestamp>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH:mm:ssZ</maven.build.timestamp.format>
     <sonar.snapshotRepository.id>snapshot</sonar.snapshotRepository.id>
@@ -383,8 +384,10 @@
           <execution>
             <id>enforce</id>
             <goals>
+              <goal>display-info</goal>
               <goal>enforce</goal>
             </goals>
+            <phase>validate</phase>
             <configuration>
               <rules>
                 <requireProperty>
@@ -424,9 +427,9 @@
                 </requireMavenVersion>
 
                 <requireJavaVersion>
-                  <message>To build this project JDK ${jdk.min.version} (or upper) is required. Please install it.
+                  <message>To build this project JDK ${enforcer.jdk.min.version} (or upper) is required. Please install it.
                   </message>
-                  <version>${jdk.min.version}</version>
+                  <version>${enforcer.jdk.min.version}</version>
                 </requireJavaVersion>
 
                 <requirePluginVersions>


### PR DESCRIPTION
This is a "works in most cases" to fix a build error when trying to still preserve Java 8 compatibility.

Context: I'm the maintainer of the sonar-groovy plugin, which still uses this parent. I currently want to keep Java 8 compatibility, while updating the build infrastructure. (See https://github.com/Inform-Software/sonar-groovy/pull/170)

The problem is now this:
- The javac release flag only accepts versions in the "modern" style, so 6, 7, 8, 9, 10, 11
- The enforcer rule [requireJavaVersion](https://maven.apache.org/enforcer/enforcer-rules/requireJavaVersion.html) builds a range restriction against a normalized version of the build JDK, which is something like `1.8.0-352` or `11.0.17`

So using `1.8` as `jdk.min.version` breaks the compiler on Java 11 and using `8` as `jdk.min.version` makes the enforcer plugin throw an error on Java 8 (since `8` > `1.8`).

Splitting this into two properties (with one deriving from the other by default) serves two purposes:
- It's good enough for most users: For example, setting `jdk.min.version` to `11` creates a version `enforcer.jdk.min.version` of `1.11`, which is still bigger then `1.8` and smaller then `11` (and we are pretty sure nobody uses anything in-between)
- If one wants to be hyper-correct (or require a different Java version for maven/enforcer and compiler), one can still overwrite both properties

This can probably be dropped some months after the next LTS release, when Java 11 is the baseline for all projects based on this.