### PR TITLE
[BUILD-2836] Use semantic versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.g
 
 After the build artifacts get promoted to the releases repository on repox, 
 they get automatically uploaded to Maven Central.
+
+To define a specific (major.minor.patch) version please update `pom.xml` `<version>x.x.x-SNAPSHOT</version>` accordingly.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.sonarsource.parent</groupId>
   <artifactId>parent</artifactId>
-  <version>66-SNAPSHOT</version>
+  <version>66.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource OSS parent</name>


### PR DESCRIPTION
# BUILD-2836
Use semantic versioning
That way it is coherent with our other projects and the way gh-action_release enforce the format x.x.x.xxxx