### PR TITLE
Prepare next snapshot release number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.sonarsource.parent</groupId>
   <artifactId>parent</artifactId>
-  <version>67.0.0-SNAPSHOT</version>
+  <version>68.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource OSS parent</name>


### PR DESCRIPTION
As defined on confluence the next version should be incremented manually.

So do I.