### PR TITLE
fix(BUILD-3886): Fix missing pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.sonarsource.parent</groupId>
   <artifactId>parent</artifactId>
-  <version>69.0.0-SNAPSHOT</version>
+  <version>70.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource OSS parent</name>
@@ -104,7 +104,7 @@
     <version.shade.plugin>3.5.0</version.shade.plugin>
     <version.source.plugin>3.3.0</version.source.plugin>
     <version.site.plugin>3.7.1</version.site.plugin>
-    <version.artifactory.plugin>3.4.0</version.artifactory.plugin>
+    <version.artifactory.plugin>3.5.1</version.artifactory.plugin>
     <version.jacoco.plugin>0.8.10</version.jacoco.plugin>
 
     <version.buildnumber.plugin>3.1.0</version.buildnumber.plugin>


### PR DESCRIPTION
- Fix missing pom by updating artifactory plugin to 3.5.1 (see https://github.com/jfrog/artifactory-maven-plugin/pull/46)
- bump project version

> Note: Artifactory plugin version 3.5.2 breaks the promotion/release workflow (Jira ticket for looking into the issue: https://sonarsource.atlassian.net/browse/BUILD-3915)