### PR TITLE
BUILD-4779 Lookup for maven dependencies with Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:re-team"
-  ]
+  ],
+  "enabledManagers": [
+    "maven",
+    "github-actions",
+    "custom.regex"
+  ],
+  "maven": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
# BUILD-4779 Lookup for maven dependencies with Renovate

## Changes
* Renovate will now also check for maven dependencies updates

# Notes
* replicates changes done on parent project:  https://github.com/SonarSource/parent/pull/99