### PR TITLE
chore(BUILD-4884): remove maven configuration from renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,13 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "github>SonarSource/renovate-config:re-team"
-  ],
-  "enabledManagers": [
-    "maven",
-    "github-actions",
-    "custom.regex"
-  ],
-  "maven": {
-    "enabled": true
-  }
+  ]
 }


### PR DESCRIPTION
depends on https://github.com/SonarSource/renovate-config/pull/26