### PR TITLE
BUILD-5090 parent oss setup pre commit validation at pr level

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,10 +1,12 @@
 env:
   ARTIFACTORY_URL: VAULT[development/kv/data/repox data.url]
   ARTIFACTORY_PRIVATE_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader
-  ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer  # Possible values for ARTIFACTORY_DEPLOY_REPO: sonarsource-private-qa, sonarsource-public-qa
+  ARTIFACTORY_DEPLOY_USERNAME: vault-${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer
   ARTIFACTORY_DEPLOY_PASSWORD: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-qa-deployer access_token]
+  # Possible values for ARTIFACTORY_DEPLOY_REPO: sonarsource-private-qa, sonarsource-public-qa
   ARTIFACTORY_DEPLOY_REPO: sonarsource-public-qa
-  ARTIFACTORY_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
+  ARTIFACTORY_ACCESS_TOKEN: >-
+    VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-private-reader access_token]
 
   # burgr notification
   BURGR_URL: VAULT[development/kv/data/burgr data.url]
@@ -24,13 +26,13 @@ container_definition: &CONTAINER_DEFINITION
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: >
-    $CIRRUS_USER_COLLABORATOR == 'true' && 
-    $CIRRUS_TAG == "" && 
-    ($CIRRUS_PR != "" 
-    || $CIRRUS_BRANCH == 'master' 
-    || $CIRRUS_BRANCH =~ "branch-.*" 
-    || $CIRRUS_BRANCH =~ "dogfood-on-.*" 
-    || $CIRRUS_BUILD_SOURCE == 'api' 
+    $CIRRUS_USER_COLLABORATOR == 'true' &&
+    $CIRRUS_TAG == "" &&
+    ($CIRRUS_PR != ""
+    || $CIRRUS_BRANCH == 'master'
+    || $CIRRUS_BRANCH =~ "branch-.*"
+    || $CIRRUS_BRANCH =~ "dogfood-on-.*"
+    || $CIRRUS_BUILD_SOURCE == 'api'
     )
 
 build_task:
@@ -63,7 +65,8 @@ promote_task:
     cpu: 1
     memory: 1G
   env:
-    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
+    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: >-
+      VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
     # artifacts that will have downloadable links in burgr
     ARTIFACTS: org.sonarsource.parent:parent:pom

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Pre-commit checks
+on:
+  pull_request:
+  merge_group:
+
+jobs:
+  pre-commit:
+    name: "pre-commit"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: SonarSource/gh-action_pre-commit@2f1b605a435e0896282366dce6ca4ce9b98705b5 # 0.0.6
+        with:
+          extra-args: >
+            --from-ref=origin/${{ github.event.pull_request.base.ref }}
+            --to-ref=${{ github.event.pull_request.head.sha }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+# Default state for all rules
+default: true
+
+MD029:
+  style: ordered

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,9 +19,9 @@ repos:
     rev: 9cce2940414e9560ae4c8518ddaee2ac1863a4d2  # frozen: v1.28.0
     hooks:
       - id: yamllint
-        args: [-d, "{extends: default, rules: {line-length: {max: 130}}}"]
-  - repo: https://github.com/markdownlint/markdownlint
-    rev: 4089e11ea61317283a50455ff73afe895b9d8b2d  # frozen: v0.11.0
+        args: [-d, "{extends: default, rules: {line-length: {max: 140}}}"]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: c9ea83146232fb263effdfe6f222d87f5395b27a # v0.39.0
     hooks:
       - id: markdownlint
   - repo: https://github.com/python-jsonschema/check-jsonschema

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
-### License
+# parent-oss
+
+## License
 
 Copyright 2009-2024 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)
 
-### Releasing
+## Releasing
 
-After the build artifacts get promoted to the releases repository on repox, 
+After the build artifacts get promoted to the releases repository on repox,
 they get automatically uploaded to Maven Central.
 
 The release process is described in [RELEASE.md](./RELEASE.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,20 +1,27 @@
 # Releasing the parent-oss project
 
-> WARN: Due to some internal tooling (releasability checks) semantic versioning is barely supported.
-> 
+> WARN: Due to some internal tooling (releasability checks)
+> semantic versioning is barely supported.
+>
 > Therefore, a new release number has to be a new **major**.
 
-Assume you want to release from version `70.0.0.x`, 
+Assume you want to release from version `70.0.0.x`,
 **the next version must be** `71.0.0.x`
-1. Prepare a new project release in [Jira](https://sonarsource.atlassian.net/projects/PARENTOSS?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page) with as version `71.0` (no patch or build number)
+
+1. Prepare a new project release in [Jira](https://sonarsource.atlassian.net/projects/PARENTOSS?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page)
+   with as version `71.0` (no patch or build number)
 
 2. Leave the Jira version status as `UNRELEASED`
 3. Update pom.xml version of parent-oss project. (example [PR](https://github.com/SonarSource/parent-oss/pull/158/files))
 4. Check that releasability checks pass on [Burgr](https://burgr.sonarsource.com/projects/SonarSource/parent-oss/main)
-5. Retrieve the last build number on [Burgr](https://burgr.sonarsource.com/projects/SonarSource/parent-oss/main) (`major.minor.patch.build-number`)
-6. On GitHub create a new release and set this number retrieved from Burgr as tag and release version
+5. Retrieve the last build number on [Burgr](https://burgr.sonarsource.com/projects/SonarSource/parent-oss/main)
+   (`major.minor.patch.build-number`)
+6. On GitHub create a new release and set this number retrieved from Burgr
+   as tag and release version
 7. Publish the release
-8. Check that the [GitHub release workflow](https://github.com/SonarSource/parent-oss/actions/workflows/release.yml) run well 
-9. Check it is gracefully deployed on [Sonatype](https://central.sonatype.com/artifact/org.sonarsource.parent/parent). 
+8. Check that the [GitHub release workflow](https://github.com/SonarSource/parent-oss/actions/workflows/release.yml)
+   run well
+9. Check it is gracefully deployed on [Sonatype](https://central.sonatype.com/artifact/org.sonarsource.parent/parent).
 
-> WARN: It can take up to 24h to have the release synchronized with Sonatype. Sometimes it is very fast sometimes not)
+> WARN: It can take up to 24h to have the release synchronized with Sonatype.
+> Sometimes it is very fast sometimes not)


### PR DESCRIPTION
# BUILD-5090 parent oss setup pre commit validation at pr level

## Changes
* Setup a pre-commit.yml workflow
  That way we ensure that pre-commit is validated at PR level
* Fix existing pre-commit issues