### PR TITLE
BUILD-5722 parent parent oss schedule nightly builds

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@b1f898b04170567791e1fd75f691f0266aab60af", "load_features") # 3.0.4
 
 def main(ctx):
   return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -21,14 +21,16 @@ container_definition: &CONTAINER_DEFINITION
 
 only_sonarsource_qa: &ONLY_SONARSOURCE_QA
   only_if: >
-    $CIRRUS_USER_COLLABORATOR == 'true' &&
-    $CIRRUS_TAG == "" &&
-    ($CIRRUS_PR != ""
-    || $CIRRUS_BRANCH == 'master'
-    || $CIRRUS_BRANCH =~ "branch-.*"
-    || $CIRRUS_BRANCH =~ "dogfood-on-.*"
-    || $CIRRUS_BUILD_SOURCE == 'api'
-    )
+    (
+      $CIRRUS_USER_COLLABORATOR == 'true' &&
+      $CIRRUS_TAG == "" &&
+      ($CIRRUS_PR != ""
+      || $CIRRUS_BRANCH == 'master'
+      || $CIRRUS_BRANCH =~ "branch-.*"
+      || $CIRRUS_BRANCH =~ "dogfood-on-.*"
+      || $CIRRUS_BUILD_SOURCE == 'api'
+      )
+    ) || $CIRRUS_CRON == 'nightly'
 
 build_task:
   <<: *ONLY_SONARSOURCE_QA


### PR DESCRIPTION
## Changes

- [x] Update cirrus-modules v2 -> v3
- [x] Enable nightly builds - That way we know day after day if the CI is working properly (ease maintenance)