### PR TITLE
BUILD-6376: Update license check configuration format

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -465,7 +465,6 @@
           </dependency>
         </dependencies>
         <configuration>
-          <header>sonarsource/licenseheaders/${license.name}.txt</header>
           <failIfMissing>true</failIfMissing>
           <strictCheck>true</strictCheck>
           <encoding>${project.build.sourceEncoding}</encoding>
@@ -483,18 +482,23 @@
             <css>SLASHSTAR_STYLE</css>
             <less>SLASHSTAR_STYLE</less>
           </mapping>
-          <includes>
-            <include>src/*/java/**/*.java</include>
-            <include>src/**/*.js</include>
-            <include>src/**/*.ts</include>
-            <include>src/**/*.tsx</include>
-            <include>src/**/*.css</include>
-            <include>src/**/*.less</include>
-            <include>tests/**/*.test.ts</include>
-          </includes>
-          <excludes>
-            <exclude>src/test/resources/**</exclude>
-          </excludes>
+          <licenseSets>
+            <licenseSet>
+              <header>sonarsource/licenseheaders/${license.name}.txt</header>
+              <includes>
+                <include>src/*/java/**/*.java</include>
+                <include>src/**/*.js</include>
+                <include>src/**/*.ts</include>
+                <include>src/**/*.tsx</include>
+                <include>src/**/*.css</include>
+                <include>src/**/*.less</include>
+                <include>tests/**/*.test.ts</include>
+              </includes>
+              <excludes>
+                <exclude>src/test/resources/**</exclude>
+              </excludes>
+            </licenseSet>
+          </licenseSets>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION






Configuration format has changed since version 4.0 of the license check plugin. From the [plugin's website](https://oss.carbou.me/license-maven-plugin/):

> NOTE: Between versions 4.0 and 3.0 the configuration syntax has been
> changed. The plugin now has the concept of License Sets, which allow you
> to work with one or more license configurations in a single execution of
> the plugin. In simple terms, a <licenseSet> wraps the previous
> configuration options for a license.

Updating the format gets rid of the following warnings in our builds:

```
[WARNING] Parameter 'legacyConfigExcludes' (user property 'license.excludes') is deprecated: use LicenseSet.excludes
[WARNING] Parameter 'legacyConfigHeader' (user property 'license.header') is deprecated: use LicenseSet.header
[WARNING] Parameter 'legacyConfigIncludes' (user property 'license.includes') is deprecated: use LicenseSet.includes
```
Same as  https://github.com/SonarSource/parent/pull/177