### PR TITLE
BUILD-9625 Update license-headers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
           <dependency>
             <groupId>org.sonarsource.license-headers</groupId>
             <artifactId>license-headers</artifactId>
-            <version>1.4.0.1404</version>
+            <version>1.5.0.16</version>
           </dependency>
         </dependencies>
         <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -461,7 +461,7 @@
           <dependency>
             <groupId>org.sonarsource.license-headers</groupId>
             <artifactId>license-headers</artifactId>
-            <version>1.5.0.16</version>
+            <version>1.6.0.21</version>
           </dependency>
         </dependencies>
         <configuration>


### PR DESCRIPTION
This pull request updates the `license-headers` dependency in the `pom.xml` file to a newer version.

* Dependency update:
  * Upgraded `org.sonarsource.license-headers:license-headers` from version `1.4.0.1404` to `1.6.0.21` in `pom.xml` to ensure access to the latest features and bug fixes and update SonarSource SA to SonarSource Sàrl
