### PR TITLE
BUILD-10792 Bump license-headers to 1.7.0.32; drop license.years

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <version.sign.plugin>1.1.0</version.sign.plugin>
     <version.cyclonedx.plugin>2.9.1</version.cyclonedx.plugin>
 
-    <!-- To configure maven-license-plugin to check license headers (dateless templates in license-headers) -->
+    <!-- To configure com.mycila:license-maven-plugin to check license headers (dateless templates in license-headers) -->
     <license.name>SSALv1</license.name>
     <license.owner>SonarSource Sàrl</license.owner>
     <license.title>${project.name}</license.title>

--- a/pom.xml
+++ b/pom.xml
@@ -119,11 +119,10 @@
     <version.sign.plugin>1.1.0</version.sign.plugin>
     <version.cyclonedx.plugin>2.9.1</version.cyclonedx.plugin>
 
-    <!-- To configure maven-license-plugin to check license headers -->
+    <!-- To configure maven-license-plugin to check license headers (dateless templates in license-headers) -->
     <license.name>SSALv1</license.name>
     <license.owner>SonarSource Sàrl</license.owner>
     <license.title>${project.name}</license.title>
-    <license.years>${project.inceptionYear}-2025</license.years>
     <license.mailto>mailto:info AT sonarsource DOT com</license.mailto>
 
     <gitRepositoryName>parent-oss</gitRepositoryName>
@@ -461,7 +460,7 @@
           <dependency>
             <groupId>org.sonarsource.license-headers</groupId>
             <artifactId>license-headers</artifactId>
-            <version>1.6.0.21</version>
+            <version>1.7.0.32</version>
           </dependency>
         </dependencies>
         <configuration>
@@ -471,7 +470,6 @@
           <properties>
             <license.owner>${license.owner}</license.owner>
             <license.title>${license.title}</license.title>
-            <license.years>${license.years}</license.years>
             <license.mailto>${license.mailto}</license.mailto>
           </properties>
           <mapping>


### PR DESCRIPTION
BUILD-10792 Bump license-headers to 1.7.0.32; drop license.years

## Context
Aligns the OSS Maven parent with [BUILD-10792](https://sonarsource.atlassian.net/browse/BUILD-10792): consume `license-headers` **1.7.0.32** (dateless templates) and stop passing `license.years` into the Mycila license-maven-plugin.

## Changes
- Dependency `org.sonarsource.license-headers:license-headers` → **1.7.0.32**
- Remove `license.years` property and `<license.years>` plugin configuration entry

## Breaking / follow-up
Child POMs that overrode `license.years` only for headers can remove those overrides. Repositories must refresh source headers when bumping parent so files match the new templates.

## Test
- [sonar-java#5536](https://github.com/SonarSource/sonar-java/pull/5536) — dogfood PR using a promoted build from this parent-oss (**SSALv1** headers refreshed with `mvn license:format` only).

## Related
- [license-headers](https://github.com/SonarSource/license-headers) release **1.7.0.32**

[BUILD-10792]: https://sonarsource.atlassian.net/browse/BUILD-10792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ