### PR TITLE
BUILD-10792 Bump version to 88.0.0-SNAPSHOT for next development iteration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.sonarsource.parent</groupId>
   <artifactId>parent</artifactId>
-  <version>87.0.0-SNAPSHOT</version>
+  <version>88.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>SonarSource OSS parent</name>


### PR DESCRIPTION
BUILD-10792 Bump version to 88.0.0-SNAPSHOT for next development iteration

Bump the OSS Maven parent to the next **`*.0.0-SNAPSHOT`** line after the **87.x** release train.

## Related
- [BUILD-10792](https://sonarsource.atlassian.net/browse/BUILD-10792)

[BUILD-10792]: https://sonarsource.atlassian.net/browse/BUILD-10792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ