### PR TITLE
BUILD-10765 Update SonarSource/gh-action_releasability to 3.0.4

### DIFF
--- a/.github/workflows/releasability.yaml
+++ b/.github/workflows/releasability.yaml
@@ -20,6 +20,6 @@ jobs:
       contents: read
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: SonarSource/gh-action_releasability/releasability-status@66c21c6a7fc93337b457f44d1590f8a9e1433cf2 # 3.0.1
+      - uses: SonarSource/gh-action_releasability/releasability-status@683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08 # 3.0.4
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Update `SonarSource/gh-action_releasability` to `683b9a1ffd08c3a23af1d1bffb67a9d7bcfb1b08` (3.0.4) for compliance with allowed versions.