### PR TITLE
BUILD-11249 Upgrade GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
         with:
           version: 2025.7.12
-      - uses: SonarSource/ci-github-actions/build-maven@master
+      - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           deploy-pull-request: true
           artifactory-reader-role: private-reader
@@ -46,4 +46,4 @@ jobs:
         with:
           version: 2025.7.12
           cache_save: false
-      - uses: SonarSource/ci-github-actions/promote@master
+      - uses: SonarSource/ci-github-actions/promote@v1

--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -10,4 +10,4 @@ jobs:
     permissions:
       actions: write
     steps:
-      - uses: SonarSource/ci-github-actions/pr_cleanup@master
+      - uses: SonarSource/ci-github-actions/pr_cleanup@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,22 @@
 ---
 name: sonar-release
-# This workflow is triggered when publishing a new github release
 # yamllint disable-line rule:truthy
 on:
-  release:
-    types:
-      - published
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version'
+        required: true
+        type: string
 
 jobs:
   release:
     permissions:
       id-token: write
       contents: write
-    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v6
+    uses: SonarSource/gh-action_release/.github/workflows/main.yaml@v7
     with:
+      version: ${{ inputs.version }}
       publishToBinaries: false
       mavenCentralSync: true
       slackChannel: squad-eng-xp-notifications


### PR DESCRIPTION
## Summary

- `ci-github-actions/build-maven`, `ci-github-actions/promote`, `ci-github-actions/pr_cleanup`: `@master` → `@v1`
- `gh-action_release/main.yaml`: `@v6` → `@v7` with `workflow_dispatch` trigger (+ required `version` input)

## Test plan

- [ ] Build CI passes on this PR
- [ ] Verify `promote` job runs on merge to master
- [ ] Trigger release manually via `workflow_dispatch` with a version input to validate v7 flow