### PR TITLE
BUILD-11539 Enable SCA scanning (unified dogfooding) for parent-oss

### DIFF
--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and run shadow scans
     permissions:
       id-token: write
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -1,0 +1,24 @@
+name: Unified Dogfooding scans
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # Daily at 04:00 UTC
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: github-ubuntu-latest-s
+    name: Build and run shadow scans
+    permissions:
+      id-token: write
+      contents: write
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+        with:
+          version: 2025.7.12
+      - uses: SonarSource/ci-github-actions/build-maven@v1
+        with:
+          run-shadow-scans: true
+          artifactory-reader-role: private-reader
+          maven-args: -Dsonar.organization=sonarsource -Dsonar.projectKey=SonarSource_parent-oss

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -13,10 +13,10 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2.4.4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
         with:
-          version: 2025.7.12
+          version: 2026.6.1
       - uses: SonarSource/ci-github-actions/build-maven@v1
         with:
           run-shadow-scans: true

--- a/.github/workflows/unified-dogfooding.yml
+++ b/.github/workflows/unified-dogfooding.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: github-ubuntu-latest-s
+    runs-on: sonar-xs
     name: Build and run shadow scans
     permissions:
       id-token: write


### PR DESCRIPTION
## Summary

Enables **SCA** for `parent-oss` to satisfy [BUILD-11539](https://sonarsource.atlassian.net/browse/BUILD-11539) (SCA enforcement starts **2026-06-16**).

Adds a scheduled `unified-dogfooding.yml` running `build-maven` with `run-shadow-scans: true`, analyzing on **Next + SonarQube Cloud EU + SonarQube Cloud US** under the unified key `SonarSource_parent-oss`.

## Why this approach (and what it deliberately avoids)

- `parent-oss` currently analyzes **only Next** under the Maven key `org.sonarsource.parent:parent`; the DX scorecard reports *Not Analyzed in SQC*.
- `run-shadow-scans: true` **auto-disables deployment**, so this workflow does **not** publish artifacts or touch the release/promote pipeline in `build.yml`.
- The existing `org.sonarsource.parent:parent` Next analysis (read by the `releasability` **QualityGate** check) is **left untouched** — the key and organization are set only inside this workflow via `maven-args`, never in the POM. This is important because `parent-oss` is an inherited parent POM; setting `sonar.*` in the POM would leak into every child project.
- `sonar.organization=sonarsource` is required for the SonarQube Cloud (SQC-EU/US) scans and is **not** injected by the scan orchestrator, so it is passed explicitly via `maven-args`.
- `SonarSource_parent-oss` matches the repo name, so the DX scorecard auto-matches it (no DX entity edit needed).
- Public repo specifics carried over from `build.yml`: `github-ubuntu-latest-s` runner and `artifactory-reader-role: private-reader` (needed to resolve dependencies).

## Prerequisite (must run before the first scan)

Run the SPEED **"Onboard onto all SonarQube instances"** action for `SonarSource/parent-oss` with the **default key** `SonarSource_parent-oss` (leave Project Keys empty). Vault tokens (`next`, `sonarcloud`, `sonarqube-us`) are auto-granted to all GitHub Actions repos.

## Test plan

- [ ] Run SPEED onboarding for `SonarSource_parent-oss` on all three instances
- [ ] Trigger via `workflow_dispatch`; confirm `ANALYSIS SUCCESSFUL` + `Gather SCA dependencies` on Next, SQC-EU and SQC-US (look for `Organization key: sonarsource`)
- [ ] Confirm `parent-oss` flips to SCA-active on the eng-xp DX scorecard
- [ ] Confirm `build.yml` / releasability are unaffected

[BUILD-11539]: https://sonarsource.atlassian.net/browse/BUILD-11539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

----
## Summary by Gitar

- **Dependency updates:**
  - Bumped `actions/checkout` to `v6.0.3` and `jdx/mise-action` to `v4.1.0`.

<sub>This will update automatically on new commits.</sub>